### PR TITLE
Let console know that we don't want ansi

### DIFF
--- a/src/symfony/provider/ConsoleContainerProvider.ts
+++ b/src/symfony/provider/ConsoleContainerProvider.ts
@@ -88,6 +88,7 @@ export class ConsoleContainerProvider implements ContainerProviderInterface {
                 args.push(infos.consolePath)
                 args = args.concat(parameters)
                 args.push("--format=json")
+                args.push("--no-ansi")
 
                 let buffer: string = ""
                 let errorBuffer: string = ""


### PR DESCRIPTION
The console debug:routing command seems to add this after the json if ran in ddev. 
Adding the --no-ansi parameter fixes this.